### PR TITLE
add default constructor for jackson

### DIFF
--- a/src/main/java/com/powsybl/study/server/dto/NetworkInfos.java
+++ b/src/main/java/com/powsybl/study/server/dto/NetworkInfos.java
@@ -8,6 +8,7 @@ package com.powsybl.study.server.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 
@@ -16,6 +17,7 @@ import java.util.UUID;
  */
 
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class NetworkInfos {
 

--- a/src/main/java/com/powsybl/study/server/dto/StudyInfos.java
+++ b/src/main/java/com/powsybl/study/server/dto/StudyInfos.java
@@ -9,12 +9,14 @@ package com.powsybl.study.server.dto;
 import io.swagger.annotations.ApiModel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * @author Abdelsalem Hedhili <abdelsalem.hedhili at rte-france.com>
  */
 
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
 @ApiModel("Study attributes")
 public class StudyInfos {

--- a/src/main/java/com/powsybl/study/server/dto/VoltageLevelAttributes.java
+++ b/src/main/java/com/powsybl/study/server/dto/VoltageLevelAttributes.java
@@ -16,6 +16,7 @@ import lombok.*;
  */
 
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
 @ApiModel("Voltage level attributes")
 public class VoltageLevelAttributes {


### PR DESCRIPTION
Signed-off-by: AbdelHedhili <abdelsalem.hedhili@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
"com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `com.powsybl.study.server.dto.NetworkInfos` (no Creators, like default construct, exist):"


**What is the new behavior (if this is a feature change)?**
no exception